### PR TITLE
correct zenodo release badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1197332.svg)](https://doi.org/10.5281/zenodo.1197332)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1198732.svg)](https://doi.org/10.5281/zenodo.1198732)
 
 shell-novice
 ============


### PR DESCRIPTION
Was linking to the git-novice-es badge.
