### PR TITLE
make lesson suitable for teaching with locally-built pages

### DIFF
--- a/_extras/about.md
+++ b/_extras/about.md
@@ -1,6 +1,4 @@
 ---
-layout: page
 title: About
-permalink: /about/
 ---
 {% include carpentries.html %}

--- a/_extras/discuss.md
+++ b/_extras/discuss.md
@@ -1,7 +1,5 @@
 ---
-layout: page
-title: "Discussion"
-permalink: /discuss/
+title: Discussion
 ---
 ## Sopa de letras
 
@@ -106,7 +104,7 @@ Y un ID de usuario,
 {: .callout}
 
 Los usuarios pueden pertenecer a cualquier número de grupos,
-cada uno de los cuales tiene un nombre de grupo único 
+cada uno de los cuales tiene un nombre de grupo único
 y un identificador numérico o ID de grupo.
 La lista de quién está en qué grupo se almacena normalmente en el archivo `/etc/group`.
 (si está delante de una máquina Unix en este momento,
@@ -251,7 +249,7 @@ El comando para cambiar los permisos del propietario a `rw-` es:
 $ chmod u=rw final.grd
 ~~~
 {: .language-bash}
- 
+
 La 'u' señala que estamos cambiando los privilegios
 del usuario (es decir, el propietario del archivo),
 y `rw` es el nuevo conjunto de permisos.
@@ -379,7 +377,7 @@ pero también es más complejo de administrar y entender en sistemas pequeños
 Algunas variantes modernas de Unix aceptan ACL, así como los permisos antiguos de lectura-escritura-ejecución,
 pero casi nadie los utiliza.
 
-> ## Challenge 
+> ## Challenge
 > Si `ls -l myfile.php` devuelve los siguientes detalles:
 >
 > ~~~
@@ -670,7 +668,7 @@ La salida nos muestra las 5 secuencias con mayor identidad a nuestra secuencia d
 información acerca de cada una de estas secuencias:
 
 1. `query acc.` - El nombre de nuestra secuencia de interés.
-2. `subject acc.` - El nombre de la secuencia con identidad a nuestra secuencia de interés.  
+2. `subject acc.` - El nombre de la secuencia con identidad a nuestra secuencia de interés.
 3. `% identity` - El porcentaje de identidad.
 4. `alignment length` - La longitud del alineamiento.
 5. `mismatches` - El número de posiciones diferentes (**mismatches**).
@@ -750,7 +748,7 @@ Analysis of Complete_ID.fasta
 * Deberá funcionar con cualquier otro archivo o archivos fasta, diferentes a los proporcionados.
 * Deberá estar comentado, explicando brevemente qué hace el **script** y qué realiza cada línea.
 
-Todas las ocurrencias de 'ID' deberán ser substituidas por un identificador, pueden usar un número entre 1 y 16. No tienen que hacer este ID variable, es decir, no es necesario que el ID se pueda cambiar en la línea de comandos cuando se ejecuta el script.  
+Todas las ocurrencias de 'ID' deberán ser substituidas por un identificador, pueden usar un número entre 1 y 16. No tienen que hacer este ID variable, es decir, no es necesario que el ID se pueda cambiar en la línea de comandos cuando se ejecuta el script.
 
 Los paquetes de archivos los pueden descargar de:
 

--- a/_extras/figures.md
+++ b/_extras/figures.md
@@ -1,6 +1,4 @@
 ---
-layout: page
 title: Figures
-permalink: /figures/
 ---
 {% include all_figures.html %}

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -1,14 +1,12 @@
 ---
-layout: page
-title: "Instructor Notes"
-permalink: /guide/
+title: Instructor Notes
 ---
 
 
 * ¿Por qué aprendemos a usar el terminal?
   * Permite a los usuarios automatizar tareas repetitivas
   * Y captura pequeños pasos de manipulación de datos que normalmente no se graban hacer la investigación reproducible
-  
+
 * El problema
   * Ejecutar el mismo flujo de trabajo en varias muestras puede ser innecesariamente laborioso
   * Manipulación manual de archivos de datos:
@@ -88,7 +86,7 @@ siempre que los alumnos que usen Windows no se encuentren con obstáculos como:
      Puede clonar el directorio shell-novice o usar `Download ZIP`
      botón a la derecha para obtener el [repositorio] completo (https://github.com/swcarpentry/shell-novice). También proporcionamos ahora
      un archivo zip del directorio `data` que se puede descargar por sí mismo
-     del repositorio haciendo clic derecho + Guardar o ver la página ["setup"] ({{page.root}} / setup /) en el sitio web de la lección para más detalles.
+     del repositorio haciendo clic derecho + Guardar o ver la página ["setup"]({{page.root}}{% link setup.md %}) en el sitio web de la lección para más detalles.
 
 * Sitio web: se han usado varias prácticas.
     * Opción 1: puede proporcionar enlaces a los alumnos antes de la lección para que puedan seguirlos,

--- a/setup.md
+++ b/setup.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Preparación
 ---
 
@@ -14,4 +13,4 @@ $ cd
 ~~~
 {: .language-bash}
 
-En la lección, aprenderás como acceder a los datos de este directorio.  
+En la lección, aprenderás como acceder a los datos de este directorio.


### PR DESCRIPTION
See discussion here for more background: https://github.com/datacarpentry/datacarpentry.github.io/issues/542

In short, some Carpentries lessons use the path `/guide/` for their Instructor Notes page and others use `/guide/index.html` (the default defined in `_config.yml`). This PR removes permalinks with a trailing slash from the YAML front matter of the Instructor Notes (`_extras/guide.md`) and other Extras files, consistent with new lessons created with [the lesson template](https://github.com/carpentries/styles/). Although there's no functional difference in the online versions of the lesson pages, pages with a trailing slash in the permalink will result in **broken links in the version of the lesson built locally**. We'd like local builds to be usable e.g. in workshops taking place at locations with limited or unreliable Internet access. 

Keeping the paths to these files consistent will also help us avoid broken links on the [Software Carpentry Lessons page](https://software-carpentry.org/lessons/), and ensure that equivalent paths in new lessons created with the template are consistent with previously-developed lessons like this one.

I did a sweep through the lesson and adjusted internal links as part of this PR. If and when this is merged, I'll also make sure the link on https://software-carpentry.org/lessons/ to the Instructor Notes page isn't broken, and make another sweep through the lesson pages too. 

Finally, I also removed the `layout` field from several pages, as the default layout is already set for Episodes and Extras pages in `_config.yml`.