### PR TITLE
Actualizar los enlaces de Slack [Update slack links]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1198732.svg)](https://doi.org/10.5281/zenodo.1198732)
-[![Create a Slack Account with us](https://img.shields.io/badge/Create_Slack_Account-The_Carpentries-071159.svg)](https://swc-slack-invite.herokuapp.com/)
-[![Slack Status](https://img.shields.io/badge/Slack_Channel-swc--shell--es-E01563.svg)](https://swcarpentry.slack.com/messages/C9WDS87R6)
+[![Create a Slack Account with us](https://img.shields.io/badge/Create_Slack_Account-The_Carpentries-071159.svg)](https://slack-invite.carpentries.org/)
+[![Slack Status](https://img.shields.io/badge/Slack_Channel-swc--shell--es-E01563.svg)](https://carpentries.slack.com/messages/C9WDS87R6)
 
 # shell-novice
 


### PR DESCRIPTION
The Carpentries actualizó recientemente la URL de su dominio de Slack y la URL de la aplicación de invitación. Este PR actualiza los enlaces para que coincidan con los nuevos dominios.

[The Carpentries recently updated their Slack domain URL and invite app URL. This PR updates the links to match the new domains.]
